### PR TITLE
Emacs の lock file を vue.config.js で監視対象外にする記事を書いた

### DIFF
--- a/content.org
+++ b/content.org
@@ -4952,3 +4952,49 @@
      このまま使い続けるのは厳しそうな雰囲気。
 
      いずれ ember-cli-rails も捨てて ember-cli 単体で動かすようにした方が良さそう
+*** DONE Emacs のロックファイルと Webpack dev server の設定          :@Emacs:
+    CLOSED: [2021-09-16 木 10:22]
+    :PROPERTIES:
+    :EXPORT_FILE_NAME: configure-webpack-dev-server-with-emacs
+    :END:
+    また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。
+
+    プライベートで vue-cli とかを使って
+    ~npm run serve~ とかしている時に
+    ファイルを変更する度に
+
+    #+begin_example
+    [Error: ENOENT: no such file or directory, stat '/path/to/src/components/.#HelloWorld.vue']
+    #+end_example
+
+    とか怒られて辛かった。
+    Emacs のロックファイルである。
+
+    ロックファイルを生成しないというのもアリかもしれないが
+    正常に保存されれば自動で消えるファイルだし
+    そこに手を入れるよりは、監視対象ファイルを制限した方が良さそう、と判断して調べた。
+
+    ~npm run serve~ では裏側で webpack-dev-server が動いているようなので
+    そこで watch 対象からロックファイルを外すべく
+    ~vue.config.js~ を以下のように設定した。
+
+    #+begin_src js
+    module.exports = {
+      configureWebpack: {
+        devServer: {
+          watchOptions: {
+            ignored: ['node_modules', 'public', '**/.#*'],
+          }
+        }
+      }
+    }
+    #+end_src
+
+    肝は ~'**/.#*'~ である。
+    Emacs のロックファイルは ~.#~ の後にオリジナルのファイル名がくっついてくる形なので
+    そいつを全部無視する、というだけ。
+
+    これでファイルを変更しても怒られなくなってハッピー。
+
+    ちなみに同じ問題が React の開発の時にも発生するので
+    多分同じような方法で直せる。まだ試してないけど。

--- a/content/posts/configure-webpack-dev-server-with-emacs.md
+++ b/content/posts/configure-webpack-dev-server-with-emacs.md
@@ -1,0 +1,42 @@
++++
+title = "Emacs のロックファイルと Webpack dev server の設定"
+date = 2021-09-16T10:22:00+09:00
+categories = ["Emacs"]
+draft = false
++++
+
+また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。
+
+プライベートで vue-cli とかを使って
+`npm run serve` とかしている時にファイルを変更する度に
+
+```text
+[Error: ENOENT: no such file or directory, stat '/path/to/src/components/.#HelloWorld.vue']
+```
+
+とか怒られて辛かった。
+Emacs のロックファイルである。
+
+ロックファイルを生成しないというのもアリかもしれないが正常に保存されれば自動で消えるファイルだしそこに手を入れるよりは、監視対象ファイルを制限した方が良さそう、と判断して調べた。
+
+`npm run serve` では裏側で webpack-dev-server が動いているようなのでそこで watch 対象からロックファイルを外すべく
+`vue.config.js` を以下のように設定した。
+
+```js
+module.exports = {
+  configureWebpack: {
+    devServer: {
+      watchOptions: {
+        ignored: ['node_modules', 'public', '**/.#*'],
+      }
+    }
+  }
+}
+```
+
+肝は `'**/.#*'` である。
+Emacs のロックファイルは `.#` の後にオリジナルのファイル名がくっついてくる形なのでそいつを全部無視する、というだけ。
+
+これでファイルを変更しても怒られなくなってハッピー。
+
+ちなみに同じ問題が React の開発の時にも発生するので多分同じような方法で直せる。まだ試してないけど。

--- a/docs/categories/emacs/index.html
+++ b/docs/categories/emacs/index.html
@@ -130,6 +130,17 @@
                 <ul class="posts-list">
                     
                         <li class="post-item">
+                            <a href="https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/">
+                                <span class="post-title">Emacs のロックファイルと Webpack dev server の設定</span>
+                                <span class="post-day">
+                                    
+                                        09月16日
+                                    
+                                </span>
+                            </a>
+                        </li>
+                    
+                        <li class="post-item">
                             <a href="https://mugijiru.github.io/posts/sticky-shift-with-key-chord/">
                                 <span class="post-title">key-chord を使って Sticky Shift を一部実現した</span>
                                 <span class="post-day">

--- a/docs/categories/emacs/index.xml
+++ b/docs/categories/emacs/index.xml
@@ -6,7 +6,16 @@
     <description>Recent content in Emacs on 麦汁三昧</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>ja-JP</language>
-    <lastBuildDate>Sun, 11 Jul 2021 13:42:00 +0900</lastBuildDate><atom:link href="https://mugijiru.github.io/categories/emacs/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 16 Sep 2021 10:22:00 +0900</lastBuildDate><atom:link href="https://mugijiru.github.io/categories/emacs/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Emacs のロックファイルと Webpack dev server の設定</title>
+      <link>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</link>
+      <pubDate>Thu, 16 Sep 2021 10:22:00 +0900</pubDate>
+      
+      <guid>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</guid>
+      <description>また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。 プライベートで vue-cli とかを使って npm run serve とかしている時にファイルを変更する度に [Error: ENOENT: no</description>
+    </item>
+    
     <item>
       <title>key-chord を使って Sticky Shift を一部実現した</title>
       <link>https://mugijiru.github.io/posts/sticky-shift-with-key-chord/</link>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -130,6 +130,17 @@
                 <ul class="posts-list">
                     
                         <li class="post-item">
+                            <a href="https://mugijiru.github.io/categories/emacs/">
+                                <span class="post-title">Emacs</span>
+                                <span class="post-day">
+                                    
+                                        09月16日
+                                    
+                                </span>
+                            </a>
+                        </li>
+                    
+                        <li class="post-item">
                             <a href="https://mugijiru.github.io/categories/rails/">
                                 <span class="post-title">Rails</span>
                                 <span class="post-day">
@@ -146,17 +157,6 @@
                                 <span class="post-day">
                                     
                                         08月22日
-                                    
-                                </span>
-                            </a>
-                        </li>
-                    
-                        <li class="post-item">
-                            <a href="https://mugijiru.github.io/categories/emacs/">
-                                <span class="post-title">Emacs</span>
-                                <span class="post-day">
-                                    
-                                        07月11日
                                     
                                 </span>
                             </a>

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -6,7 +6,16 @@
     <description>Recent content in Categories on 麦汁三昧</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>ja-JP</language>
-    <lastBuildDate>Sun, 22 Aug 2021 00:50:00 +0900</lastBuildDate><atom:link href="https://mugijiru.github.io/categories/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 16 Sep 2021 10:22:00 +0900</lastBuildDate><atom:link href="https://mugijiru.github.io/categories/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Emacs</title>
+      <link>https://mugijiru.github.io/categories/emacs/</link>
+      <pubDate>Thu, 16 Sep 2021 10:22:00 +0900</pubDate>
+      
+      <guid>https://mugijiru.github.io/categories/emacs/</guid>
+      <description></description>
+    </item>
+    
     <item>
       <title>Ember-js</title>
       <link>https://mugijiru.github.io/categories/ember-js/</link>
@@ -22,15 +31,6 @@
       <pubDate>Sun, 22 Aug 2021 00:50:00 +0900</pubDate>
       
       <guid>https://mugijiru.github.io/categories/rails/</guid>
-      <description></description>
-    </item>
-    
-    <item>
-      <title>Emacs</title>
-      <link>https://mugijiru.github.io/categories/emacs/</link>
-      <pubDate>Sun, 11 Jul 2021 13:42:00 +0900</pubDate>
-      
-      <guid>https://mugijiru.github.io/categories/emacs/</guid>
       <description></description>
     </item>
     

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -6,7 +6,16 @@
     <description>Recent content on 麦汁三昧</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>ja-JP</language>
-    <lastBuildDate>Sun, 22 Aug 2021 00:50:00 +0900</lastBuildDate><atom:link href="https://mugijiru.github.io/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 16 Sep 2021 10:22:00 +0900</lastBuildDate><atom:link href="https://mugijiru.github.io/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Emacs のロックファイルと Webpack dev server の設定</title>
+      <link>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</link>
+      <pubDate>Thu, 16 Sep 2021 10:22:00 +0900</pubDate>
+      
+      <guid>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</guid>
+      <description>また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。 プライベートで vue-cli とかを使って npm run serve とかしている時にファイルを変更する度に [Error: ENOENT: no</description>
+    </item>
+    
     <item>
       <title>ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした</title>
       <link>https://mugijiru.github.io/posts/ember-cli-rails-with-rails6-without-deprecation-warning/</link>

--- a/docs/posts/configure-webpack-dev-server-with-emacs/index.html
+++ b/docs/posts/configure-webpack-dev-server-with-emacs/index.html
@@ -15,16 +15,16 @@
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="author" content="">
-<meta name="description" content="ember-cli-rails なアプリを Rails6 対応にしてみた。が、リリースされている Gem をそのまま使うと DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper, ActionText::TagHelper, and EmberCliRailsAssetsHelper. Being able to do this is deprecated. Autoloading during initialization is going to be an error condition in future versions of Rails. Reloading does not" />
+<meta name="description" content="また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。 プライベートで vue-cli とかを使って npm run serve とかしている時にファイルを変更する度に [Error: ENOENT: no" />
 <meta name="keywords" content="blog,developer,personal" />
 <meta name="robots" content="noodp" />
 <meta name="theme-color" content="" />
-<link rel="canonical" href="https://mugijiru.github.io/posts/ember-cli-rails-with-rails6-without-deprecation-warning/" />
+<link rel="canonical" href="https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/" />
 
 
     <title>
         
-            ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした :: 麦汁三昧 
+            Emacs のロックファイルと Webpack dev server の設定 :: 麦汁三昧 
         
     </title>
 
@@ -46,26 +46,24 @@
 
 
 
-<meta itemprop="name" content="ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした">
-<meta itemprop="description" content="ember-cli-rails なアプリを Rails6 対応にしてみた。が、リリースされている Gem をそのまま使うと DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper, ActionText::TagHelper, and EmberCliRailsAssetsHelper. Being able to do this is deprecated. Autoloading during initialization is going to be an error condition in future versions of Rails. Reloading does not"><meta itemprop="datePublished" content="2021-08-22T00:50:00&#43;09:00" />
-<meta itemprop="dateModified" content="2021-08-22T00:50:00&#43;09:00" />
-<meta itemprop="wordCount" content="545">
+<meta itemprop="name" content="Emacs のロックファイルと Webpack dev server の設定">
+<meta itemprop="description" content="また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。 プライベートで vue-cli とかを使って npm run serve とかしている時にファイルを変更する度に [Error: ENOENT: no"><meta itemprop="datePublished" content="2021-09-16T10:22:00&#43;09:00" />
+<meta itemprop="dateModified" content="2021-09-16T10:22:00&#43;09:00" />
+<meta itemprop="wordCount" content="393">
 <meta itemprop="keywords" content="" />
 <meta name="twitter:card" content="summary"/>
-<meta name="twitter:title" content="ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした"/>
-<meta name="twitter:description" content="ember-cli-rails なアプリを Rails6 対応にしてみた。が、リリースされている Gem をそのまま使うと DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper, ActionText::TagHelper, and EmberCliRailsAssetsHelper. Being able to do this is deprecated. Autoloading during initialization is going to be an error condition in future versions of Rails. Reloading does not"/>
+<meta name="twitter:title" content="Emacs のロックファイルと Webpack dev server の設定"/>
+<meta name="twitter:description" content="また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。 プライベートで vue-cli とかを使って npm run serve とかしている時にファイルを変更する度に [Error: ENOENT: no"/>
 
 
 
 
 
-    <meta property="article:section" content="Rails" />
-
-    <meta property="article:section" content="Ember-js" />
+    <meta property="article:section" content="Emacs" />
 
 
 
-    <meta property="article:published_time" content="2021-08-22 00:50:00 &#43;0900 &#43;0900" />
+    <meta property="article:published_time" content="2021-09-16 10:22:00 &#43;0900 &#43;0900" />
 
 
 
@@ -132,7 +130,7 @@
           <circle cx="12" cy="12" r="10"></circle>
           <polyline points="12 6 12 12 16 14"></polyline>
         </svg>
-        2 minutes
+        One minute
 
         
       </p>
@@ -140,54 +138,34 @@
 
     <article>
       <h1 class="post-title">
-        <a href="https://mugijiru.github.io/posts/ember-cli-rails-with-rails6-without-deprecation-warning/">ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした</a>
+        <a href="https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/">Emacs のロックファイルと Webpack dev server の設定</a>
       </h1>
 
       
 
       <div class="post-content">
-        <p>ember-cli-rails なアプリを Rails6 対応にしてみた。が、リリースされている Gem をそのまま使うと</p>
-<blockquote>
-<p>DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper, ActionText::TagHelper, and EmberCliRailsAssetsHelper.</p>
-<p>Being able to do this is deprecated. Autoloading during initialization is going
-to be an error condition in future versions of Rails.</p>
-<p>Reloading does not reboot the application, and therefore code executed during
-initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
-the expected changes won&rsquo;t be reflected in that stale Module object.</p>
-<p>These autoloaded constants have been unloaded.</p>
-<p>Please, check the &ldquo;Autoloading and Reloading Constants&rdquo; guide for solutions.
-(called from &lt;top (required)&gt; at /app/config/environment.rb:5)</p>
-</blockquote>
-<p>という Deprecation Warning が出てつらかった。</p>
-<h2 id="原因">原因</h2>
-<p><a href="https://github.com/thoughtbot/ember-cli-rails/tree/v0.11.0">ember-cli-rails@0.11.0</a> 及びそれが依存している <a href="https://github.com/seanpdoyle/ember-cli-rails-assets/tree/v0.6.2">ember-cli-rails-assets@0.6.2</a> ではまだ Rails6 の Deprecation Warning への対応が入っていなかった。</p>
-<h2 id="解決方法">解決方法</h2>
-<p>よくよく調べると
-ember-cli-rails の方は既にマージされている
-<a href="https://github.com/thoughtbot/ember-cli-rails/pull/587">https://github.com/thoughtbot/ember-cli-rails/pull/587</a>
-で対応がされていて、
-ember-cli-rails-assets の方は
-<a href="https://github.com/seanpdoyle/ember-cli-rails-assets/pull/12">https://github.com/seanpdoyle/ember-cli-rails-assets/pull/12</a>
-に対応ブランチが用意されていた。</p>
-<p>というわけで、
-ember-cli-rails の方は master から
-ember-cli-rails-assets は上のプルリクエストのブランチを使うように
-Gemfile を書き換えるだけで済んだ。</p>
-<p>が、とりあえず master を見るのはいつか知らない間に更新が入りそうで怖いので
-ember-cli-rails は現在の最新の ref を取るようにしている。</p>
-<p>というわけで以下のような書き方になった。</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-ruby" data-lang="ruby">gem <span style="color:#e6db74">&#39;ember-cli-rails&#39;</span>, <span style="color:#e6db74">github</span>: <span style="color:#e6db74">&#39;thoughtbot/ember-cli-rails&#39;</span>, <span style="color:#e6db74">ref</span>: <span style="color:#e6db74">&#39;1e56a03fb8437f52dfd450454c71cffda2981d66&#39;</span>
-gem <span style="color:#e6db74">&#39;ember-cli-rails-assets&#39;</span>, <span style="color:#e6db74">github</span>: <span style="color:#e6db74">&#39;seanpdoyle/ember-cli-rails-assets&#39;</span>, <span style="color:#e6db74">branch</span>: <span style="color:#e6db74">&#39;rely-on-engine-to-load-helper&#39;</span>
-</code></pre></div><p>ということを ember-cli-rails-app というリポジトリの
-<a href="https://github.com/mugijiru/ember-rails-todo-app/pull/109">https://github.com/mugijiru/ember-rails-todo-app/pull/109</a>
-で対応した。</p>
-<p>なお Rails6 には
-<a href="https://github.com/mugijiru/ember-rails-todo-app/pull/106/files">https://github.com/mugijiru/ember-rails-todo-app/pull/106/files</a>
-でアップグレードしている。結果的にはこのプルリクエストでは rails app:update して load_defaults を 6.0 にして関係ない Warning を潰しただけになっていたりする。</p>
-<h2 id="その他">その他</h2>
-<p>ember-cli-rails は
-Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエストや Issue が放置されてるのでこのまま使い続けるのは厳しそうな雰囲気。</p>
-<p>いずれ ember-cli-rails も捨てて ember-cli 単体で動かすようにした方が良さそう</p>
+        <p>また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。</p>
+<p>プライベートで vue-cli とかを使って
+<code>npm run serve</code> とかしている時にファイルを変更する度に</p>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-text" data-lang="text">[Error: ENOENT: no such file or directory, stat &#39;/path/to/src/components/.#HelloWorld.vue&#39;]
+</code></pre></div><p>とか怒られて辛かった。
+Emacs のロックファイルである。</p>
+<p>ロックファイルを生成しないというのもアリかもしれないが正常に保存されれば自動で消えるファイルだしそこに手を入れるよりは、監視対象ファイルを制限した方が良さそう、と判断して調べた。</p>
+<p><code>npm run serve</code> では裏側で webpack-dev-server が動いているようなのでそこで watch 対象からロックファイルを外すべく
+<code>vue.config.js</code> を以下のように設定した。</p>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-js" data-lang="js"><span style="color:#a6e22e">module</span>.<span style="color:#a6e22e">exports</span> <span style="color:#f92672">=</span> {
+  <span style="color:#a6e22e">configureWebpack</span><span style="color:#f92672">:</span> {
+    <span style="color:#a6e22e">devServer</span><span style="color:#f92672">:</span> {
+      <span style="color:#a6e22e">watchOptions</span><span style="color:#f92672">:</span> {
+        <span style="color:#a6e22e">ignored</span><span style="color:#f92672">:</span> [<span style="color:#e6db74">&#39;node_modules&#39;</span>, <span style="color:#e6db74">&#39;public&#39;</span>, <span style="color:#e6db74">&#39;**/.#*&#39;</span>],
+      }
+    }
+  }
+}
+</code></pre></div><p>肝は <code>'**/.#*'</code> である。
+Emacs のロックファイルは <code>.#</code> の後にオリジナルのファイル名がくっついてくる形なのでそいつを全部無視する、というだけ。</p>
+<p>これでファイルを変更しても怒られなくなってハッピー。</p>
+<p>ちなみに同じ問題が React の開発の時にも発生するので多分同じような方法で直せる。まだ試してないけど。</p>
 
       </div>
     </article>
@@ -200,8 +178,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
     <p>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-folder meta-icon"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
 
-        <span class="tag"><a href="https://mugijiru.github.io/categories/rails/">Rails</a></span>
-        <span class="tag"><a href="https://mugijiru.github.io/categories/ember-js/">Ember-js</a></span>
+        <span class="tag"><a href="https://mugijiru.github.io/categories/emacs/">Emacs</a></span>
         
     </p>
 
@@ -214,7 +191,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
           <line x1="16" y1="17" x2="8" y2="17"></line>
           <polyline points="10 9 9 9 8 9"></polyline>
         </svg>
-        545 Words
+        393 Words
       </p>
 
       <p>
@@ -225,7 +202,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
           <line x1="3" y1="10" x2="21" y2="10"></line>
         </svg>
         
-          2021年08月21日 15:50
+          2021年09月16日 01:22
         
 
          
@@ -236,7 +213,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
       <hr />
       <div class="sharing-buttons">
         
-<a class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_blank" rel="noopener" aria-label="" title="Share on facebook">
+<a class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_blank" rel="noopener" aria-label="" title="Share on facebook">
   <div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"></path></svg>
     </div>
@@ -244,7 +221,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?url=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_blank" rel="noopener" aria-label="" title="Share on twitter">
+<a class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?url=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_blank" rel="noopener" aria-label="" title="Share on twitter">
   <div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small">
       <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"></path></svg>
@@ -253,7 +230,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://www.tumblr.com/widgets/share/tool?posttype=link&amp;title=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f&amp;caption=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f&amp;canonicalUrl=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_blank" rel="noopener" aria-label="" title="Share on tumblr">
+<a class="resp-sharing-button__link" href="https://www.tumblr.com/widgets/share/tool?posttype=link&amp;title=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a&amp;caption=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a&amp;canonicalUrl=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_blank" rel="noopener" aria-label="" title="Share on tumblr">
   <div class="resp-sharing-button resp-sharing-button--tumblr resp-sharing-button--small">
     <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.563 24c-5.093 0-7.031-3.756-7.031-6.411V9.747H5.116V6.648c3.63-1.313 4.512-4.596 4.71-6.469C9.84.051 9.941 0 9.999 0h3.517v6.114h4.801v3.633h-4.82v7.47c.016 1.001.375 2.371 2.207 2.371h.09c.631-.02 1.486-.205 1.936-.419l1.156 3.425c-.436.636-2.4 1.374-4.156 1.404h-.178l.011.002z"/></svg>
@@ -262,7 +239,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="mailto:?subject=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f&amp;body=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_self" rel="noopener" aria-label="" title="Share via email">
+<a class="resp-sharing-button__link" href="mailto:?subject=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a&amp;body=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_self" rel="noopener" aria-label="" title="Share via email">
   <div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
     </div>
@@ -270,7 +247,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f&amp;media=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f;description=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f" target="_blank" rel="noopener" aria-label="" title="Share on pinterest">
+<a class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f&amp;media=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f;description=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a" target="_blank" rel="noopener" aria-label="" title="Share on pinterest">
   <div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12.017 0C5.396 0 .029 5.367.029 11.987c0 5.079 3.158 9.417 7.618 11.162-.105-.949-.199-2.403.041-3.439.219-.937 1.406-5.957 1.406-5.957s-.359-.72-.359-1.781c0-1.663.967-2.911 2.168-2.911 1.024 0 1.518.769 1.518 1.688 0 1.029-.653 2.567-.992 3.992-.285 1.193.6 2.165 1.775 2.165 2.128 0 3.768-2.245 3.768-5.487 0-2.861-2.063-4.869-5.008-4.869-3.41 0-5.409 2.562-5.409 5.199 0 1.033.394 2.143.889 2.741.099.12.112.225.085.345-.09.375-.293 1.199-.334 1.363-.053.225-.172.271-.401.165-1.495-.69-2.433-2.878-2.433-4.646 0-3.776 2.748-7.252 7.92-7.252 4.158 0 7.392 2.967 7.392 6.923 0 4.135-2.607 7.462-6.233 7.462-1.214 0-2.354-.629-2.758-1.379l-.749 2.848c-.269 1.045-1.004 2.352-1.498 3.146 1.123.345 2.306.535 3.55.535 6.607 0 11.985-5.365 11.985-11.987C23.97 5.39 18.592.026 11.985.026L12.017 0z"/></svg>
     </div>
@@ -278,7 +255,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f&amp;title=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f&amp;summary=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f&amp;source=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_blank" rel="noopener" aria-label="" title="Share on linkedin">
+<a class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f&amp;title=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a&amp;summary=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a&amp;source=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_blank" rel="noopener" aria-label="" title="Share on linkedin">
   <div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
     </div>
@@ -286,7 +263,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://reddit.com/submit/?url=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f&amp;resubmit=true&amp;title=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f" target="_blank" rel="noopener" aria-label="" title="Share on reddit">
+<a class="resp-sharing-button__link" href="https://reddit.com/submit/?url=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f&amp;resubmit=true&amp;title=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a" target="_blank" rel="noopener" aria-label="" title="Share on reddit">
   <div class="resp-sharing-button resp-sharing-button--reddit resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
     </div>
@@ -294,7 +271,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://www.xing.com/app/user?op=share;url=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f;title=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f" target="_blank" rel="noopener" aria-label="" title="Share on xing">
+<a class="resp-sharing-button__link" href="https://www.xing.com/app/user?op=share;url=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f;title=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a" target="_blank" rel="noopener" aria-label="" title="Share on xing">
   <div class="resp-sharing-button resp-sharing-button--xing resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M18.188 0c-.517 0-.741.325-.927.66 0 0-7.455 13.224-7.702 13.657.015.024 4.919 9.023 4.919 9.023.17.308.436.66.967.66h3.454c.211 0 .375-.078.463-.22.089-.151.089-.346-.009-.536l-4.879-8.916c-.004-.006-.004-.016 0-.022L22.139.756c.095-.191.097-.387.006-.535C22.056.078 21.894 0 21.686 0h-3.498zM3.648 4.74c-.211 0-.385.074-.473.216-.09.149-.078.339.02.531l2.34 4.05c.004.01.004.016 0 .021L1.86 16.051c-.099.188-.093.381 0 .529.085.142.239.234.45.234h3.461c.518 0 .766-.348.945-.667l3.734-6.609-2.378-4.155c-.172-.315-.434-.659-.962-.659H3.648v.016z"/></svg>
     </div>
@@ -302,7 +279,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="whatsapp://send?text=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f%20https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_blank" rel="noopener" aria-label="" title="Share on whatsapp">
+<a class="resp-sharing-button__link" href="whatsapp://send?text=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a%20https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_blank" rel="noopener" aria-label="" title="Share on whatsapp">
   <div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>
     </div>
@@ -310,7 +287,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://news.ycombinator.com/submitlink?u=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f&amp;t=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f" target="_blank" rel="noopener" aria-label="" title="Share on hacker news">
+<a class="resp-sharing-button__link" href="https://news.ycombinator.com/submitlink?u=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f&amp;t=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a" target="_blank" rel="noopener" aria-label="" title="Share on hacker news">
   <div class="resp-sharing-button resp-sharing-button--hackernews resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M0 24V0h24v24H0zM6.951 5.896l4.112 7.708v5.064h1.583v-4.972l4.148-7.799h-1.749l-2.457 4.875c-.372.745-.688 1.434-.688 1.434s-.297-.708-.651-1.434L8.831 5.896h-1.88z"/></svg>
     </div>
@@ -318,7 +295,7 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 </a>
 
 
-<a class="resp-sharing-button__link" href="https://telegram.me/share/url?text=ember-cli-rails%20%e3%82%a2%e3%83%97%e3%83%aa%e3%81%a7%20Rails6%20%e3%81%ae%20Deprecation%20Warning%20%e3%81%8c%e5%87%ba%e3%81%aa%e3%81%84%e3%82%88%e3%81%86%e3%81%ab%e3%81%97%e3%81%9f&amp;url=https%3a%2f%2fmugijiru.github.io%2fposts%2fember-cli-rails-with-rails6-without-deprecation-warning%2f" target="_blank" rel="noopener" aria-label="" title="Share on telegram">
+<a class="resp-sharing-button__link" href="https://telegram.me/share/url?text=Emacs%20%e3%81%ae%e3%83%ad%e3%83%83%e3%82%af%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab%e3%81%a8%20Webpack%20dev%20server%20%e3%81%ae%e8%a8%ad%e5%ae%9a&amp;url=https%3a%2f%2fmugijiru.github.io%2fposts%2fconfigure-webpack-dev-server-with-emacs%2f" target="_blank" rel="noopener" aria-label="" title="Share on telegram">
   <div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
     </div>
@@ -336,18 +313,11 @@ Ruby 3.0 対応のプルリクエストも含めて結構なプルリクエス�
 
         <div class="pagination__buttons">
           
-            <span class="button previous">
-              <a href="https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/">
-                <span class="button__icon">←</span>
-                <span class="button__text">Emacs のロックファイルと Webpack dev server の設定</span>
-              </a>
-            </span>
-          
 
           
             <span class="button next">
-              <a href="https://mugijiru.github.io/posts/sticky-shift-with-key-chord/">
-                <span class="button__text">key-chord を使って Sticky Shift を一部実現した</span>
+              <a href="https://mugijiru.github.io/posts/ember-cli-rails-with-rails6-without-deprecation-warning/">
+                <span class="button__text">ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした</span>
                 <span class="button__icon">→</span>
               </a>
             </span>

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -130,6 +130,17 @@
                 <ul class="posts-list">
                     
                         <li class="post-item">
+                            <a href="https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/">
+                                <span class="post-title">Emacs のロックファイルと Webpack dev server の設定</span>
+                                <span class="post-day">
+                                    
+                                        09月16日
+                                    
+                                </span>
+                            </a>
+                        </li>
+                    
+                        <li class="post-item">
                             <a href="https://mugijiru.github.io/posts/ember-cli-rails-with-rails6-without-deprecation-warning/">
                                 <span class="post-title">ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした</span>
                                 <span class="post-day">
@@ -333,17 +344,6 @@
                                 <span class="post-day">
                                     
                                         02月23日
-                                    
-                                </span>
-                            </a>
-                        </li>
-                    
-                        <li class="post-item">
-                            <a href="https://mugijiru.github.io/posts/ember-rails-partial-modulize/">
-                                <span class="post-title">古い ember-rails App で一部ファイルを ES6 Module 化</span>
-                                <span class="post-day">
-                                    
-                                        02月21日
                                     
                                 </span>
                             </a>

--- a/docs/posts/index.xml
+++ b/docs/posts/index.xml
@@ -5,8 +5,40 @@
         <description>Recent content in Posts on 麦汁三昧</description>
         <generator>Hugo -- gohugo.io</generator>
         <language>ja-JP</language>
-        <lastBuildDate>Sun, 22 Aug 2021 00:50:00 +0900</lastBuildDate>
+        <lastBuildDate>Thu, 16 Sep 2021 10:22:00 +0900</lastBuildDate>
         <atom:link href="https://mugijiru.github.io/posts/index.xml" rel="self" type="application/rss+xml" />
+        
+        <item>
+            <title>Emacs のロックファイルと Webpack dev server の設定</title>
+            <link>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</link>
+            <pubDate>Thu, 16 Sep 2021 10:22:00 +0900</pubDate>
+            
+            <guid>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</guid>
+            <description>また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。 プライベートで vue-cli とかを使って npm run serve とかしている時にファイルを変更する度に [Error: ENOENT: no</description>
+            <content type="html"><![CDATA[<p>また同じ罠を踏んだ時に同じ対応ができるようにということでメモ。</p>
+<p>プライベートで vue-cli とかを使って
+<code>npm run serve</code> とかしている時にファイルを変更する度に</p>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-text" data-lang="text">[Error: ENOENT: no such file or directory, stat &#39;/path/to/src/components/.#HelloWorld.vue&#39;]
+</code></pre></div><p>とか怒られて辛かった。
+Emacs のロックファイルである。</p>
+<p>ロックファイルを生成しないというのもアリかもしれないが正常に保存されれば自動で消えるファイルだしそこに手を入れるよりは、監視対象ファイルを制限した方が良さそう、と判断して調べた。</p>
+<p><code>npm run serve</code> では裏側で webpack-dev-server が動いているようなのでそこで watch 対象からロックファイルを外すべく
+<code>vue.config.js</code> を以下のように設定した。</p>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-js" data-lang="js"><span style="color:#a6e22e">module</span>.<span style="color:#a6e22e">exports</span> <span style="color:#f92672">=</span> {
+  <span style="color:#a6e22e">configureWebpack</span><span style="color:#f92672">:</span> {
+    <span style="color:#a6e22e">devServer</span><span style="color:#f92672">:</span> {
+      <span style="color:#a6e22e">watchOptions</span><span style="color:#f92672">:</span> {
+        <span style="color:#a6e22e">ignored</span><span style="color:#f92672">:</span> [<span style="color:#e6db74">&#39;node_modules&#39;</span>, <span style="color:#e6db74">&#39;public&#39;</span>, <span style="color:#e6db74">&#39;**/.#*&#39;</span>],
+      }
+    }
+  }
+}
+</code></pre></div><p>肝は <code>'**/.#*'</code> である。
+Emacs のロックファイルは <code>.#</code> の後にオリジナルのファイル名がくっついてくる形なのでそいつを全部無視する、というだけ。</p>
+<p>これでファイルを変更しても怒られなくなってハッピー。</p>
+<p>ちなみに同じ問題が React の開発の時にも発生するので多分同じような方法で直せる。まだ試してないけど。</p>
+]]></content>
+        </item>
         
         <item>
             <title>ember-cli-rails アプリで Rails6 の Deprecation Warning が出ないようにした</title>

--- a/docs/posts/page/2/index.html
+++ b/docs/posts/page/2/index.html
@@ -130,6 +130,17 @@
                 <ul class="posts-list">
                     
                         <li class="post-item">
+                            <a href="https://mugijiru.github.io/posts/ember-rails-partial-modulize/">
+                                <span class="post-title">古い ember-rails App で一部ファイルを ES6 Module 化</span>
+                                <span class="post-day">
+                                    
+                                        02月21日
+                                    
+                                </span>
+                            </a>
+                        </li>
+                    
+                        <li class="post-item">
                             <a href="https://mugijiru.github.io/posts/publish-ember-rails-app/">
                                 <span class="post-title">ember-rails で書いた Web アプリを GitHub で公開した</span>
                                 <span class="post-day">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,7 +3,19 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://mugijiru.github.io/categories/</loc>
-    <lastmod>2021-08-22T00:50:00+09:00</lastmod>
+    <lastmod>2021-09-16T10:22:00+09:00</lastmod>
+  </url><url>
+    <loc>https://mugijiru.github.io/categories/emacs/</loc>
+    <lastmod>2021-09-16T10:22:00+09:00</lastmod>
+  </url><url>
+    <loc>https://mugijiru.github.io/posts/configure-webpack-dev-server-with-emacs/</loc>
+    <lastmod>2021-09-16T10:22:00+09:00</lastmod>
+  </url><url>
+    <loc>https://mugijiru.github.io/posts/</loc>
+    <lastmod>2021-09-16T10:22:00+09:00</lastmod>
+  </url><url>
+    <loc>https://mugijiru.github.io/</loc>
+    <lastmod>2021-09-16T10:22:00+09:00</lastmod>
   </url><url>
     <loc>https://mugijiru.github.io/posts/ember-cli-rails-with-rails6-without-deprecation-warning/</loc>
     <lastmod>2021-08-22T00:50:00+09:00</lastmod>
@@ -11,17 +23,8 @@
     <loc>https://mugijiru.github.io/categories/ember-js/</loc>
     <lastmod>2021-08-22T00:50:00+09:00</lastmod>
   </url><url>
-    <loc>https://mugijiru.github.io/posts/</loc>
-    <lastmod>2021-08-22T00:50:00+09:00</lastmod>
-  </url><url>
     <loc>https://mugijiru.github.io/categories/rails/</loc>
     <lastmod>2021-08-22T00:50:00+09:00</lastmod>
-  </url><url>
-    <loc>https://mugijiru.github.io/</loc>
-    <lastmod>2021-08-22T00:50:00+09:00</lastmod>
-  </url><url>
-    <loc>https://mugijiru.github.io/categories/emacs/</loc>
-    <lastmod>2021-07-11T13:42:00+09:00</lastmod>
   </url><url>
     <loc>https://mugijiru.github.io/posts/sticky-shift-with-key-chord/</loc>
     <lastmod>2021-07-11T13:42:00+09:00</lastmod>


### PR DESCRIPTION
Emacs の lock file は正常保存されると削除されるが
webpack-dev-server の監視対象になると
保存する度にファイルが消されるので
「このファイルがないよ!」って言ってサーバが強制終了される。

というわけでそれが起きないように
vue.config.js で webpack-dev-server の監視対象から外す、
という記事を書いた